### PR TITLE
Add information about the physical coordinate space.

### DIFF
--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -540,9 +540,9 @@ template <typename T, int stencil> class FsGrid {
        *
        * \param cellsToSend How many cells are going to be sent by this task
        */
-      void setupForTransferOut(int cellsToRecieve) {
+      void setupForTransferOut(int cellsToReceive) {
          // Make sure we have sufficient buffer space to store our mpi requests
-         requests.resize(localSize[0]*localSize[1]*localSize[2] + cellsToRecieve);
+         requests.resize(localSize[0]*localSize[1]*localSize[2] + cellsToReceive);
          numRequests=0;
       }
 

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -765,10 +765,27 @@ template <typename T, int stencil> class FsGrid {
          return &data[id];
       }
 
-      /*! Physical grid spacing.
+      /*! Physical grid spacing and physical coordinate space start.
        * TODO: Should this be private and have accesor-functions?
        */
       double DX,DY,DZ;
+      std::array<double,3> physicalGlobalStart;
+
+      /*! Get the physical coordinates in the global simulation space for
+       * the given cell.
+       *
+       * \param x local x-Coordinate, in cells
+       * \param y local y-Coordinate, in cells
+       * \param z local z-Coordinate, in cells
+       */
+      std::array<double, 3>&& getPhysicalCoords(int x, int y, int z) {
+         std::array<double, 3> coords;
+         coords[0] = physicalGlobalStart[0] + (localStart[0]+x)*DX;
+         coords[1] = physicalGlobalStart[1] + (localStart[1]+x)*DY;
+         coords[2] = physicalGlobalStart[2] + (localStart[2]+x)*DZ;
+
+         return coords;
+      }
 
       /*! Debugging output helper function. Allows for nicely formatted printing
        * of grid contents. Since the grid data format is varying, the actual

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -781,8 +781,8 @@ template <typename T, int stencil> class FsGrid {
       std::array<double, 3> getPhysicalCoords(int x, int y, int z) {
          std::array<double, 3> coords;
          coords[0] = physicalGlobalStart[0] + (localStart[0]+x)*DX;
-         coords[1] = physicalGlobalStart[1] + (localStart[1]+x)*DY;
-         coords[2] = physicalGlobalStart[2] + (localStart[2]+x)*DZ;
+         coords[1] = physicalGlobalStart[1] + (localStart[1]+y)*DY;
+         coords[2] = physicalGlobalStart[2] + (localStart[2]+z)*DZ;
 
          return coords;
       }

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -778,7 +778,7 @@ template <typename T, int stencil> class FsGrid {
        * \param y local y-Coordinate, in cells
        * \param z local z-Coordinate, in cells
        */
-      std::array<double, 3>&& getPhysicalCoords(int x, int y, int z) {
+      std::array<double, 3> getPhysicalCoords(int x, int y, int z) {
          std::array<double, 3> coords;
          coords[0] = physicalGlobalStart[0] + (localStart[0]+x)*DX;
          coords[1] = physicalGlobalStart[1] + (localStart[1]+x)*DY;


### PR DESCRIPTION
This will be required both for physical initialization of simulations
directly inside the FSgrid, as well as direct simulation output, and
visualization grid specification.