### PR TITLE
Combined coupling for multiple FSGrid instances

### DIFF
--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -27,6 +27,22 @@
 #include <stdint.h>
 #include <cassert>
 
+struct FsGridCouplingInformation {
+   std::vector<int> externalRank; //!< MPI rank that each cell is being communicated to externally
+
+   void setCouplingSize(size_t totalStorageSize) {
+
+      // Set up coupling information to external grid (fill with MPI_PROC_NULL to begin with)
+      // Before actual grid coupling can be done, this information has to be filled in.
+      if(externalRank.size() != totalStorageSize) {
+         externalRank.resize(totalStorageSize);
+      }
+      for(uint i=0; i<externalRank.size(); i++) {
+         externalRank[i] = MPI_PROC_NULL;
+      }
+   }
+};
+
 /*! Simple cartesian, non-loadbalancing MPI Grid for use with the fieldsolver
  *
  * \param T datastructure containing the field in each cell which this grid manages
@@ -44,8 +60,8 @@ template <typename T, int stencil> class FsGrid {
        * \param MPI_Comm The MPI communicator this grid should use.
        * \param isPeriodic An array specifying, for each dimension, whether it is to be treated as periodic.
        */
-      FsGrid(std::array<int32_t,3> globalSize, MPI_Comm parent_comm, std::array<bool,3> isPeriodic)
-            : globalSize(globalSize) {
+   FsGrid(std::array<int32_t,3> globalSize, MPI_Comm parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation& coupling)
+            : globalSize(globalSize),coupling(coupling) {
          int status;
          int size;
 
@@ -184,7 +200,7 @@ template <typename T, int stencil> class FsGrid {
             totalStorageSize *= storageSize[i];
          }
          data.resize(totalStorageSize);
-
+         coupling.setCouplingSize(totalStorageSize);
 
          MPI_Datatype mpiTypeT;
          MPI_Type_contiguous(sizeof(T), MPI_BYTE, &mpiTypeT);
@@ -291,13 +307,6 @@ template <typename T, int stencil> class FsGrid {
                MPI_Type_commit(&(neighbourReceiveType[i]));
             if(neighbourSendType[i] != MPI_DATATYPE_NULL)
                MPI_Type_commit(&(neighbourSendType[i]));
-         }
-         
-         // Also set up coupling information to external grid (fill with MPI_PROC_NULL to begin with)
-         // Before actual grid coupling can be done, this information has to be filled in.
-         externalRank.resize(totalStorageSize);
-         for(uint i=0; i<externalRank.size(); i++) {
-            externalRank[i] = MPI_PROC_NULL;
          }
 
 
@@ -416,8 +425,8 @@ template <typename T, int stencil> class FsGrid {
          numRequests=0;
 
          // If previous coupling information was present, remove it.
-         for(uint i=0; i<externalRank.size(); i++) {
-            externalRank[i] = MPI_PROC_NULL;
+         for(uint i=0; i<coupling.externalRank.size(); i++) {
+            coupling.externalRank[i] = MPI_PROC_NULL;
          }
 
          for(int z=0; z<localSize[2]; z++) {
@@ -426,7 +435,8 @@ template <typename T, int stencil> class FsGrid {
                   // Calculate LocalID for this cell
                   LocalID thisCell = LocalIDForCoords(x,y,z);
                   assert(numRequests < requests.size());
-                  status = MPI_Irecv(&externalRank[thisCell], 1, MPI_INT, MPI_ANY_SOURCE, thisCell, comm3d,
+                  assert(thisCell < coupling.externalRank.size());
+                  status = MPI_Irecv(&coupling.externalRank[thisCell], 1, MPI_INT, MPI_ANY_SOURCE, thisCell, comm3d,
                         &requests[numRequests++]);
                   if(status != MPI_SUCCESS) {
                      std::cerr << "Error setting up MPI Irecv in FsGrid::setupForGridCoupling" << std::endl;
@@ -484,8 +494,8 @@ template <typename T, int stencil> class FsGrid {
                   // Calculate LocalID for this cell
                   LocalID thisCell = LocalIDForCoords(x,y,z);
                   assert(numRequests < requests.size());
-                  status = MPI_Irecv(get(thisCell), sizeof(T), MPI_BYTE, externalRank[thisCell], thisCell, comm3d,
-                        &requests[numRequests++]);
+                  status = MPI_Irecv(get(thisCell), sizeof(T), MPI_BYTE, coupling.externalRank[thisCell],
+                                     thisCell, comm3d, &requests[numRequests++]);
                   if(status != MPI_SUCCESS) {
                      std::cerr << "Error setting up MPI Irecv in FsGrid::setupForTransferIn" << std::endl;
                   }
@@ -568,7 +578,7 @@ template <typename T, int stencil> class FsGrid {
                   // Calculate LocalID for this cell
                   LocalID thisCell = LocalIDForCoords(x,y,z);
                   assert(numRequests < requests.size());
-                  status = MPI_Isend(get(thisCell), sizeof(T), MPI_BYTE, externalRank[thisCell], thisCell, comm3d,
+                  status = MPI_Isend(get(thisCell), sizeof(T), MPI_BYTE, coupling.externalRank[thisCell], thisCell, comm3d,
                         &requests[numRequests++]);
                   if(status != MPI_SUCCESS) {
                      std::cerr << "Error setting up MPI Isend in FsGrid::setupForTransferOut" << std::endl;
@@ -824,8 +834,7 @@ template <typename T, int stencil> class FsGrid {
       int rank; //!< This task's rank in the communicator
       std::vector<MPI_Request> requests;
       uint numRequests;
-
-      std::vector<int> externalRank; //!< MPI rank that each cell is being communicated to externally
+      FsGridCouplingInformation& coupling;
 
       std::array<int, 27> neighbour; //!< Tasks of the 26 neighbours (plus ourselves)
       std::vector<char> neighbour_index; //!< Lookup table from rank to index in the neighbour array


### PR DESCRIPTION
Instead of having redundant grid coupling information for multiple fsgrid instances, this information is outsourced to a separate data structure, which can be shared among them.

Note this needs a slightly changed grid setup, as the coupling information datastructure needs to be passed as a reference to the constructor.