### PR TITLE
Add an assignment operator to easily copy data from one FsGrid to another.

### DIFF
--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -923,16 +923,18 @@ template <typename T, int stencil> class FsGrid {
       }
 
       //! Copy the entire data from another FsGrid of the same signature over.
-      void copyDataFromOther(const FsGrid<T, stencil>& other) {
+      FsGrid<T, stencil>& operator=(const FsGrid<T, stencil>& other) {
 
          // Don't copy if sizes mismatch.
          // (Should this instead crash the program?)
          if(other.localSize[0] != localSize[0]   ||
             other.localSize[1] != localSize[1]   ||
             other.localSize[2] != localSize[2]) {
-            return;
+            return *this;
          }
          data = other.data;
+
+         return *this;
       }
    
       //! Helper function: calculate position of the local coordinate space for the given dimension

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -921,6 +921,19 @@ template <typename T, int stencil> class FsGrid {
             throw std::runtime_error("FSGrid computeDomainDecomposition failed");
          }
       }
+
+      //! Copy the entire data from another FsGrid of the same signature over.
+      void copyDataFromOther(const FsGrid<T, stencil>& other) {
+
+         // Don't copy if sizes mismatch.
+         // (Should this instead crash the program?)
+         if(other.localSize[0] != localSize[0]   ||
+            other.localSize[1] != localSize[1]   ||
+            other.localSize[2] != localSize[2]) {
+            return;
+         }
+         data = other.data;
+      }
    
       //! Helper function: calculate position of the local coordinate space for the given dimension
       // \param globalCells Number of cells in the global Simulation, in this dimension


### PR DESCRIPTION
Grids of identical size and type signature can then easily get their data assigned, without a need to loop through the cells to copy them.