### PR TITLE
HDF5 Implementation for fsgrid

### DIFF
--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -22,8 +22,9 @@
 */
 
 template<class T, int stencil> void timeit(std::array<int32_t, 3> globalSize, std::array<bool, 3> isPeriodic, int iterations){
-   double t1,t2;   
-   FsGrid<T ,stencil> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic);
+   double t1,t2;
+   FsGridCouplingInformation gridCoupling;
+   FsGrid<T ,stencil> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic,gridCoupling);
    int rank,size;
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
    MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -33,8 +33,9 @@ int main(int argc, char** argv) {
    // Create a 8×8 Testgrid
    std::array<int32_t, 3> globalSize{20,20,1};
    std::array<bool, 3> isPeriodic{false,false,true};
+   FsGridCouplingInformation gridCoupling;
    {
-      FsGrid<int,1> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic);
+      FsGrid<int,1> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic,gridCoupling);
 /*
       if(rank == 0) {
          std::cerr << " --- Test task mapping functions ---" << std::endl;
@@ -190,9 +191,7 @@ int main(int argc, char** argv) {
          }
       }
    }
-      
 
-      
       MPI_Finalize();
 
       return 0;


### PR DESCRIPTION
I was looking for a way to debug my Euler solver which now uses fsgrid. Because I am more familiar with HDF5 I implemented it into fsgrid. Now all MPI tasks can collectively write hyper-slabs  in parallel and the output variables are specified  with an
```
 std::map<int,string> 
```
where int is the array count, usually following some enum
and string the variable name in the output file

The code block for the HDF5 IO is in an ifdef block so no added dependencies  when compiling Vlasiator.

Of course this is not ready yet and I am not even sure if we need it but I am going to add units and attributes in the future while building this code.