### PR TITLE
New FsGrids operators and t_lerp method

### DIFF
--- a/tests/Makefile
+++ b/tests/Makefile
@@ -1,9 +1,11 @@
-CXX=CC
+CXX=mpic++
 CXXFLAGS= -O3 -std=c++11 -march=native -g -Wall
 
-all: benchmark test ddtest
+all: benchmark test ddtest operators
 
 benchmark: benchmark.cpp ../fsgrid.hpp
+	$(CXX) $(CXXFLAGS) -o $@ $<
+operators: operators.cpp ../fsgrid.hpp
 	$(CXX) $(CXXFLAGS) -o $@ $<
 test: test.cpp ../fsgrid.hpp
 	$(CXX) $(CXXFLAGS) -o $@ $<
@@ -11,4 +13,4 @@ ddtest: ddtest.cpp
 	$(CXX) $(CXXFLAGS) -o $@ $<
 
 clean:
-	-rm test
+	-rm test benchmark ddtest operators

--- a/tests/benchmark.cpp
+++ b/tests/benchmark.cpp
@@ -22,8 +22,9 @@
 */
 
 template<class T, int stencil> void timeit(std::array<int32_t, 3> globalSize, std::array<bool, 3> isPeriodic, int iterations){
-   double t1,t2;   
-   FsGrid<T ,stencil> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic);
+   double t1,t2;
+   FsGridCouplingInformation gridCoupling;
+   FsGrid<T ,stencil> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic,gridCoupling);
    int rank,size;
    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
    MPI_Comm_size(MPI_COMM_WORLD, &size);

--- a/tests/operators.cpp
+++ b/tests/operators.cpp
@@ -1,0 +1,81 @@
+#include <iostream>
+#include "../fsgrid.hpp"
+/*
+  Copyright (C) 2016 Finnish Meteorological Institute
+  Copyright (C) 2016 CSC -IT Center for Science 
+
+  This file is part of fsgrid
+ 
+  fsgrid is free software: you can redistribute it and/or modify
+  it under the terms of the GNU General Public License as published by
+  the Free Software Foundation, either version 3 of the License, or
+  (at your option) any later version.
+
+  fsgrid is distributed in the hope that it will be useful,
+  but WITHOUT ANY WARRANTY;
+  without even the implied warranty of
+  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+  GNU General Public License for more details.
+
+  You should have received a copy of the GNU General Public License
+  along with fsgrid.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+
+
+int main(int argc, char** argv) {
+   typedef float Real;
+   MPI_Init(&argc,&argv);
+
+   int rank,size;
+   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+   MPI_Comm_size(MPI_COMM_WORLD, &size);
+
+   // Create a 8×8 Testgrid
+   std::array<int32_t, 3> globalSize{2000,1000,1};
+   std::array<int32_t, 3> globalSize2{3000,1000,1};
+   std::array<bool, 3> isPeriodic{false,false,true};
+
+
+
+   FsGridCouplingInformation gridCoupling;
+   FsGrid<std::array<Real, 1>, 2> A(globalSize, MPI_COMM_WORLD, isPeriodic, gridCoupling);
+   FsGrid<std::array<Real, 1>, 2> B(globalSize, MPI_COMM_WORLD, isPeriodic, gridCoupling);
+   FsGrid<std::array<Real, 1>, 2> C(globalSize, MPI_COMM_WORLD, isPeriodic, gridCoupling);
+   FsGrid<std::array<Real, 1>, 2> D(globalSize2, MPI_COMM_WORLD, isPeriodic, gridCoupling);
+
+  //  FsGrid<std::array<float, 1>, 2> newGuy(A + B);
+   //  + 
+   A=B+C;
+  //  +=
+  A+=B;
+  // -
+  A=A-C;
+  // -=
+  A-=B;
+  D=D*3.0;
+  C=lerp_t(A,B,5.,10.,7.);
+  //supposed to fail;
+  // A=B+D;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+   MPI_Finalize();
+   return 0;
+}

--- a/tests/test.cpp
+++ b/tests/test.cpp
@@ -33,8 +33,9 @@ int main(int argc, char** argv) {
    // Create a 8×8 Testgrid
    std::array<int32_t, 3> globalSize{20,20,1};
    std::array<bool, 3> isPeriodic{false,false,true};
+   FsGridCouplingInformation gridCoupling;
    {
-      FsGrid<int,1> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic);
+      FsGrid<int,1> testGrid(globalSize, MPI_COMM_WORLD, isPeriodic,gridCoupling);
 /*
       if(rank == 0) {
          std::cerr << " --- Test task mapping functions ---" << std::endl;
@@ -190,9 +191,7 @@ int main(int argc, char** argv) {
          }
       }
    }
-      
 
-      
       MPI_Finalize();
 
       return 0;


### PR DESCRIPTION
-This PR implements new operators for FsGrid . 
-Now one can use ```+, -,+=,-=,*,*=,/,/=``` with FsGrid data structures.
-There is also a new ```lerp_t``` method which linearly interpolates between two existing FsGrids. It can be used like this:
-This PR also updates the tests so handles #20 and that can be closed if you want.
```
  FsGrid<std::array<Real, 10>, 2> res=lerp_t(A,B,t_a,t_b,t);

```
 where 
 
- ```A,B``` are  FsGrids of same signature
-  ```t_a,t_b``` are timestamps that corespond to A and B
- t is the timestamp of the interpolated FsGrid ```res```

I have implemented a few ways to make it more safe. For example we do not want to add a string to a perB field I guess :D
I also have a new test ```test/operators.cpp``` that demos some of the added functionality.
Let me know what you think and what I should change :)
