### PR TITLE
Add FS-split feature (completion of stage 1/2)

### DIFF
--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -814,7 +814,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
        */
       void updateGhostCells() {
 
-         if(comm3d == comm3d_aux) return;
+         if(rank == -1) return;
 
          //TODO, faster with simultaneous isends& ireceives?
          std::array<MPI_Request, 27> receiveRequests;

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -250,6 +250,8 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
          for(int i = 0; i < (parentSize - 1) / size; i++){
             int dest = (colorFs != MPI_UNDEFINED) ? parentRank + i * size + (parentSize - 1) 
                % size + 1 : MPI_PROC_NULL;
+            if(dest >= parentSize) 
+               dest = MPI_PROC_NULL;
             MPI_Isend(&rank, 1, MPI_INT, dest, 9274, parent_comm, &request[2 * i]);
             MPI_Isend(taskPosition.data(), 3, MPI_INT, dest, 9275, parent_comm, &request[2 * i + 1]);
          }

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -149,8 +149,12 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
          int status;
          int size;
 
+         ///////////////// This is a TEMPORARY solution only ////////////////
          MPI_Comm_size(parent_comm, &size);
-         size = 1; //The number of FS processes [HARD CODED FOR NOW]
+         //if(size >= 4){
+         //   size = 4; //The number of FS processes [HARD CODED FOR NOW]
+         //}
+         ////////////////////////////////////////////////////////////////////
 
          // Heuristically choose a good domain decomposition for our field size
          computeDomainDecomposition(globalSize, size, ntasks);

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -147,9 +147,9 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
    FsGrid(std::array<int32_t,3> globalSize, MPI_Comm parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation* coupling)
             : globalSize(globalSize), coupling(coupling), parent_comm(parent_comm) {
          int status;
+         size = 30; //The number of FS processes [HARD CODED FOR NOW]
 
          // Heuristically choose a good domain decomposition for our field size
-         size = 30; //The number of FS processes [HARD CODED FOR NOW]
          computeDomainDecomposition(globalSize, size, ntasks);
          
          //set private array
@@ -165,6 +165,16 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
          MPI_Comm_rank(parent_comm, &parentRank);
          int parentSize;
          MPI_Comm_size(parent_comm, &parentSize);
+
+         // Check that the number of FS processes makes sense
+         if(size > parentSize){
+            std::cerr << "Too many FS processes are being requested!" << std::endl;
+            throw std::runtime_error("FSGrid communicator setup failed");
+         }
+         else if(size < 1){
+            std::cerr << "Less than one FS process is being requested!" << std::endl;
+            throw std::runtime_error("FSGrid communicator setup failed");
+         }
 
          // Create a temporary FS subcommunicator for the MPI_Cart_create
          MPI_Comm fsComm;

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -243,7 +243,8 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
                << std::endl;
            }
          }
-         
+
+#ifdef FSGRID_DEBUG
          // All FS ranks send their true comm3d rank and taskPosition data to dest
          MPI_Request *request = new MPI_Request[(parentSize - 1) / size * 2 + 2];
          for(int i = 0; i < (parentSize - 1) / size; i++){
@@ -276,6 +277,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             }
          }
          delete[] request;
+#endif // FSGRID_DEBUG
 
          // Set correct task position for non-FS ranks
          if(colorFs == MPI_UNDEFINED){

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -149,6 +149,14 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
          int status;
          int size;
 
+         // NULL communicator indicates that this rank should not run field solver
+         if(parent_comm == MPI_COMM_NULL){
+            localSize[0] == 0;
+            localSize[1] == 0;
+            localSize[2] == 0;
+            return;
+         }
+
          status = MPI_Comm_size(parent_comm, &size);
 
          // Heuristically choose a good domain decomposition for our field size

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -279,11 +279,12 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
 
          // If non-FS process, set rank to -1 and localSize to zero and return
          if(colorFs == MPI_UNDEFINED){
-            comm3d = comm3d_aux;
             rank = -1;
             localSize[0] = 0;
             localSize[1] = 0;
             localSize[2] = 0;
+            comm3d = comm3d_aux;
+            comm3d_aux = MPI_COMM_NULL;
             return;
          }
 

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -146,14 +146,14 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
       typedef int64_t GlobalID;
 
    // Legacy constructor from coupling reference
-   FsGrid(std::array<int32_t,3> globalSize, MPI_Comm& parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation& coupling) : FsGrid(globalSize, parent_comm, isPeriodic, &coupling) {}
+   FsGrid(std::array<int32_t,3> globalSize, MPI_Comm parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation& coupling) : FsGrid(globalSize, parent_comm, isPeriodic, &coupling) {}
 
       /*! Constructor for this grid.
        * \param globalSize Cell size of the global simulation domain.
        * \param MPI_Comm The MPI communicator this grid should use.
        * \param isPeriodic An array specifying, for each dimension, whether it is to be treated as periodic.
        */
-   FsGrid(std::array<int32_t,3> globalSize, MPI_Comm& parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation* coupling)
+   FsGrid(std::array<int32_t,3> globalSize, MPI_Comm parent_comm, std::array<bool,3> isPeriodic, FsGridCouplingInformation* coupling)
             : globalSize(globalSize), coupling(coupling){
          int status;
          int size;

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -237,6 +237,10 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
                << std::endl;
            }
          }
+
+         // Free temporary communicators
+         MPI_Comm_free(&auxComm);
+         MPI_Comm_free(&fsComm);
          
          // All FS ranks send their true comm3d rank and taskPosition data to the 
          // rank 'parentRank + (parentSize - size)'
@@ -497,7 +501,11 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             if(neighbourSendType[i] != MPI_DATATYPE_NULL)
                MPI_Type_free(&(neighbourSendType[i]));
          }
-         MPI_Comm_free(&comm3d);
+         if(comm3d != MPI_COMM_NULL)
+            MPI_Comm_free(&comm3d);
+
+         if(comm3d_aux != MPI_COMM_NULL)
+            MPI_Comm_free(&comm3d_aux);
       }
 
       /*! Returns the task responsible, and its localID for handling the cell with the given GlobalID

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -482,20 +482,6 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             }
          }
 
-         // Determine size of our local grid
-         for(int i=0; i<3; i++) {
-            localSize[i] = calcLocalSize(globalSize[i],ntasksPerDim[i], taskPosition[i]);
-            localStart[i] = calcLocalStart(globalSize[i],ntasksPerDim[i], taskPosition[i]);
-         }
-
-         if(  localSize[0] == 0 || (globalSize[0] > stencil && localSize[0] < stencil)
-           || localSize[1] == 0 || (globalSize[1] > stencil && localSize[1] < stencil)
-           || localSize[2] == 0 || (globalSize[2] > stencil && localSize[2] < stencil)) {
-            std::cerr << "FSGrid space partitioning leads to a space that is too small on Rank " << rank << ". ProcessBox was [" << localSize[0] << ", " << localSize[1] << ", " << localSize[2] <<"]" <<std::endl;
-            std::cerr << "Please run with a different number of Tasks, so that space is better divisible." <<std::endl;
-            throw std::runtime_error("FSGrid too small domains");
-         }
-
          // Allocate local storage array
          size_t totalStorageSize=1;
          for(int i=0; i<3; i++) {

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -526,6 +526,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
               return std::pair<int,LocalID>(MPI_PROC_NULL,0);
            }
          }
+
          // The rank is obtained from 'comm3d' for FS ranks
          if(comm3d != MPI_COMM_NULL){
             status = MPI_Cart_rank(comm3d, taskIndex.data(), &retVal.first);
@@ -793,6 +794,9 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
       /*! Perform ghost cell communication.
        */
       void updateGhostCells() {
+
+         if(comm3d == MPI_COMM_NULL) return;
+
          //TODO, faster with simultaneous isends& ireceives?
          std::array<MPI_Request, 27> receiveRequests;
          std::array<MPI_Request, 27> sendRequests;

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -284,7 +284,6 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             isPeriodicInt[i] = (int)isPeriodic[i];
             ntasksInt[i] = (int)ntasksPerDim[i];
          }  
-<<<<<<< HEAD
 
          // Create a temporary FS subcommunicator for the MPI_Cart_create
          int colorFs = (parentRank < size) ? 1 : MPI_UNDEFINED;
@@ -293,7 +292,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
          if(colorFs != MPI_UNDEFINED){
            // Create cartesian communicator. Note, that reorder is false so
            // ranks match the ones in parent_comm
-           status = MPI_Cart_create(comm1d, 3, ntasks.data(), isPeriodicInt.data(), 0, &comm3d);
+           status = MPI_Cart_create(comm1d, 3, ntasksPerDim.data(), isPeriodicInt.data(), 0, &comm3d);
 
            if(status != MPI_SUCCESS) {
              std::cerr << "Creating cartesian communicatior failed when attempting to create FsGrid!" << std::endl;
@@ -327,7 +326,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
 
          if(colorAux != MPI_UNDEFINED){
            // Create an aux cartesian communicator corresponding to the comm3d (but shidted).
-           status = MPI_Cart_create(comm1d_aux, 3, ntasks.data(), isPeriodicInt.data(), 0, &comm3d_aux);
+           status = MPI_Cart_create(comm1d_aux, 3, ntasksPerDim.data(), isPeriodicInt.data(), 0, &comm3d_aux);
            if(status != MPI_SUCCESS) {
              std::cerr << "Creating cartesian communicatior failed when attempting to create FsGrid!" << std::endl;
              throw std::runtime_error("FSGrid communicator setup failed");
@@ -392,8 +391,8 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
 
          // Determine size of our local grid
          for(int i=0; i<3; i++) {
-            localSize[i] = calcLocalSize(globalSize[i],ntasks[i], taskPosition[i]);
-            localStart[i] = calcLocalStart(globalSize[i],ntasks[i], taskPosition[i]);
+            localSize[i] = calcLocalSize(globalSize[i],ntasksPerDim[i], taskPosition[i]);
+            localStart[i] = calcLocalStart(globalSize[i],ntasksPerDim[i], taskPosition[i]);
          }
 
          if(  localSize[0] == 0 || (globalSize[0] > stencil && localSize[0] < stencil)
@@ -483,9 +482,6 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             }
          }
 
-<<<<<<< HEAD
-=======
-
          // Determine size of our local grid
          for(int i=0; i<3; i++) {
             localSize[i] = calcLocalSize(globalSize[i],ntasksPerDim[i], taskPosition[i]);
@@ -500,7 +496,6 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             throw std::runtime_error("FSGrid too small domains");
          }
 
->>>>>>> fcc1376712a706c5c819050acac55b35b9b5f291
          // Allocate local storage array
          size_t totalStorageSize=1;
          for(int i=0; i<3; i++) {
@@ -1205,7 +1200,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
 
       /*! Get the number of ranks in the FsGrid communicator */
       int getSize() {
-        return ntasks[0] * ntasks[1] * ntasks[2];
+        return ntasksPerDim[0] * ntasksPerDim[1] * ntasksPerDim[2];
       }
 
       /*! Get in which directions, if any, this grid is periodic */

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -551,17 +551,17 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
             }
          }
 
-         // Get the local task number (matches with global) from the communicator
+         // Get the task number from the communicator
          std::pair<int,LocalID> retVal;
          int status = MPI_Cart_rank(comm3d, taskIndex.data(), &retVal.first);
          if(status != MPI_SUCCESS) {
-           std::cerr << "Unable to find FsGrid rank for global ID " << id << " (coordinates [";
-           for(int i=0; i<3; i++) {
-              std::cerr << cell[i] << ", ";
-           }
-           std::cerr << "]" << std::endl;
-           return std::pair<int,LocalID>(MPI_PROC_NULL,0);
-         }  
+            std::cerr << "Unable to find FsGrid rank for global ID " << id << " (coordinates [";
+            for(int i=0; i<3; i++) {
+               std::cerr << cell[i] << ", ";
+            }
+            std::cerr << "]" << std::endl;
+            return std::pair<int,LocalID>(MPI_PROC_NULL,0);
+         }
 
          // Determine localID of that cell within the target task
          std::array<int, 3> thatTasksStart;

--- a/fsgrid.hpp
+++ b/fsgrid.hpp
@@ -549,9 +549,7 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
 
          // Get the local task number (matches with global) from the communicator
          std::pair<int,LocalID> retVal;
-         int status;
-
-         status = MPI_Cart_rank(comm3d, taskIndex.data(), &retVal.first);
+         int status = MPI_Cart_rank(comm3d, taskIndex.data(), &retVal.first);
          if(status != MPI_SUCCESS) {
            std::cerr << "Unable to find FsGrid rank for global ID " << id << " (coordinates [";
            for(int i=0; i<3; i++) {
@@ -560,10 +558,6 @@ template <typename T, int stencil> class FsGrid : public FsGridTools{
            std::cerr << "]" << std::endl;
            return std::pair<int,LocalID>(MPI_PROC_NULL,0);
          }  
-
-         // int RR;
-         // MPI_Comm_rank(MPI_COMM_WORLD, &RR);
-         // printf("RR: %d, id: %lld, t[0]: %d, t[1]: %d,t[2]: %d, comm3d: %d, comm3d_aux: %d, retval: %d \n",RR,id,taskIndex[0],taskIndex[1],taskIndex[2],comm3d, comm3d_aux,retVal.first);fflush(stdout);MPI_Barrier(MPI_COMM_WORLD);
 
          // Determine localID of that cell within the target task
          std::array<int, 3> thatTasksStart;


### PR DESCRIPTION
This PR adds a possibility to request optional FSGrid ranks that do not contain any cells, and should be nearly free of any overhead by Vlasiator Field Solver calculation or MPI communication. Such ranks that do not contain any cells, still create a valid FSGrid objects containing useful knowledge such as the global-ID-to-task-mappings in order to avoid introducing any additional MPI communication overhead in the Vlasiator [gridGlue.cpp](https://github.com/hokkanen/vlasiator/blob/0c48f7e3b0129c2c62fd249addb027c66bd22f34/fieldsolver/gridGlue.cpp#L89). However, no changes to [gridGlue.cpp](https://github.com/hokkanen/vlasiator/blob/0c48f7e3b0129c2c62fd249addb027c66bd22f34/fieldsolver/gridGlue.cpp#L89) are required.

This PR is fully backwards compatible, meaning that FSGrid interface does not change, and no changes to the used Vlasiator versions are required if the new FS-split feature is not used. All existing features should work without need for any changes. The PR passes all Vlasiator testpackage tests when not using FS-split feature, and when using FS-split feature, all tests except the ionosphere are passed (FS-split feature does not currently support ionosphere calculation).

However, in order to maintain backwards compatibility in this pre-release, the FS-Split feature is, for the time being (while not in production use yet), activated by setting a runtime environment variable "FSGRID_PROCS" to indicate the number of requested FS-ranks that contain cells, eg,
```
export FSGRID_PROCS=4
```
The value is used only if it is an integer greater than zero, and smaller than the number of ranks in the communicator passed to the FSGrid constructor. For example, if the `MPI_COMM_WORLD` communicator contains 16 ranks, and this communicator is passed to the FSGrid constructor, while `FSGRID_PROCS=4` is set, then the FSGrid domain decomposition is only done across the global ranks 0, 1, 2, and 3. The remaining 12 global "non-FS" ranks (4 - 15) will still return valid FSGrid objects. These non-FS ranks can be identified from their local "rank" which is set to -1, and the `localSize` of each dimension which is 0.

Furthermore, in order to use the new FS-Split feature in Vlasiator, a few minor changes are required in the Vlasiator dev-branch (same changes likely suffice for other branches as well) as shown by [this](https://github.com/fmihpc/vlasiator/pull/926/files) PR. 

Note! This PR completes only the first stage of making Vlasiator Vlasov and Field Solver run in separate ranks. Vlasov solver ranks still run on all global processes, but the PR allows controlling the number of processes used by the Field Solver. This may already give important insight together with Field Solver GPU port, and work relating to the GPU-GPU communication between Field Solver and Vlasov solver. Therefore, I would like to get this commit merged with fsgrid repo soonish, because there are other FSGrid changes likely coming from the cudasiator Field Solver GPU port, and also potentially the domain decomposition change for GPU-aware MPI communications. It is important that these are compatible with the FS-split implementation.
